### PR TITLE
fix(core): selectively sync attune concurrency from Obelisk

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -104,13 +104,5 @@ export async function executeQuery(scriptContent: string): Promise<unknown> {
  * 二次检查 daemon heartbeat，避免 CLI 在 App 接管写入时绕过所有权规则。
  */
 export async function executeAttune(scriptContent: string): Promise<unknown> {
-  assertReadableSchema();
-  const build = buildIndex() as { reason?: string } | undefined;
-  if (build?.reason === 'daemon_active') {
-    throw new Error('Trajex daemon owns index writes; attune is read-only until the daemon stops');
-  }
-  if (build?.reason === 'writer_busy' || build?.reason === 'database_busy') {
-    throw new Error('Trajex index writer is busy; attune was not applied');
-  }
   return runInSandboxWorker('attune', scriptContent);
 }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -9,7 +9,7 @@
  * schema 初始化和 FTS 重建。桌面 App 可通过结构接口复用上层逻辑。
  */
 // node:sqlite lifecycle and migrations for the Core package.
-import { mkdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -45,6 +45,22 @@ function openReadDb(): NodeSqliteDb {
   return db;
 }
 
+/** 打开既有记忆层：attune 不创建、迁移或配置索引，避免与 daemon 索引写入争夺所有权。 */
+function openAttuneDb(): NodeSqliteDb {
+  if (!existsSync(DB_PATH)) {
+    throw new Error('Trajex index is not initialized; run an index build before writing approved durable memory');
+  }
+  const db = new DatabaseSync(DB_PATH);
+  configureConnection(db, { busyTimeoutMs: 250 });
+  const required = ['memories', 'memories_fts', 'memories_fts_ai', 'memories_fts_ad', 'memories_fts_au'];
+  const present = new Set(db.prepare("SELECT name FROM sqlite_master WHERE name IN ('memories', 'memories_fts', 'memories_fts_ai', 'memories_fts_ad', 'memories_fts_au')").all().map(row => String(row.name)));
+  if (required.some(name => !present.has(name))) {
+    db.close();
+    throw new Error('Trajex index predates the approved durable memory layer; run an index build first');
+  }
+  return db;
+}
+
 /** 打开独立锁库；该连接只承载 writer lease，不承载业务表。 */
 function openWriterLeaseDb(lockPath: string): NodeSqliteDb {
   return new DatabaseSync(lockPath);
@@ -56,4 +72,4 @@ function rebuildMemoryFts(db: SqliteDb): void {
 }
 
 
-export { CLAUDE_DIR, CODEX_DIR, TRAJEX_DIR, DB_PATH, TEXT_LIMIT, openDb, openReadDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };
+export { CLAUDE_DIR, CODEX_DIR, TRAJEX_DIR, DB_PATH, TEXT_LIMIT, openDb, openReadDb, openAttuneDb, openWriterLeaseDb, rebuildMemoryFts, trunc, truncJson, extractText, extractContentType, extractMessageIsMeta, filePath, isDir, readLines };

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -9,6 +9,7 @@
  * 已打开的 SQLite 连接，不负责索引调度或 VM 执行。
  */
 // Query and attune sandbox helpers for the Core package.
+import { randomUUID } from 'node:crypto';
 import { statSync } from 'node:fs';
 import { isAbsolute, normalize, resolve, sep } from 'node:path';
 import { createBuiltinProviderRegistry } from './providers/builtins.ts';
@@ -617,7 +618,7 @@ function createQueryApi(
 /**
  * 创建记忆层的最小写 API。与查询 API 分开，确保 executeAttune() 才能获得写能力。
  */
-function createAttuneApi(db: SqliteDb) {
+function createAttuneApi(db: SqliteDb, runMutation: <T>(work: () => T) => T = work => work()) {
   const resolveMemoryPath = (memoryPath: string, sessionId?: string): string => {
     let base = null;
     if (sessionId) {
@@ -636,18 +637,31 @@ function createAttuneApi(db: SqliteDb) {
     return resolved;
   };
 
-  /** 写入一条记忆（INSERT OR REPLACE），返回新记录的关键字段。 */
+  /** 写入一条记忆；主键冲突时生成新 UUID，绝不覆盖已有记忆。 */
   const remember = ({ path: memoryPath, session_id, message_start, message_end, summary, project }: RememberInput) => {
     if (!memoryPath || !summary) throw new Error('remember() requires path and summary');
     assertEnglishMemoryText(summary, 'remember() summary');
     const normalizedPath = resolveMemoryPath(memoryPath, session_id);
-    const id = `mem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const proj = project || (session_id
       ? db.prepare('SELECT project FROM sessions WHERE id=?').get(session_id)?.project || null
       : null);
     const created_at = new Date().toISOString();
-    db.prepare('INSERT OR REPLACE INTO memories (id, session_id, project, message_start, message_end, path, summary, created_at) VALUES (?,?,?,?,?,?,?,?)').run(
-      id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, summary, created_at);
+    let id = `mem-${randomUUID()}`;
+    runMutation(() => {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+          db.prepare('INSERT INTO memories (id, session_id, project, message_start, message_end, path, summary, created_at) VALUES (?,?,?,?,?,?,?,?)').run(
+            id, session_id || null, proj, message_start || null, message_end || null, normalizedPath, summary, created_at);
+          return;
+        } catch (error) {
+          if (attempt < 2 && (error as { errcode?: unknown }).errcode === 1555) {
+            id = `mem-${randomUUID()}`;
+            continue;
+          }
+          throw error;
+        }
+      }
+    });
     return { id, path: normalizedPath, project: proj, created_at };
   };
 
@@ -655,14 +669,16 @@ function createAttuneApi(db: SqliteDb) {
   const forget = ({ id, reason }: ForgetInput) => {
     const deletionReason = String(reason || '').trim();
     if (!id || !deletionReason) throw new Error('forget() requires id and reason');
-    const row = db.prepare('SELECT id, deleted_at, deleted_reason FROM memories WHERE id=?').get(id);
-    if (!row) throw new Error(`forget() memory not found: ${id}`);
-    if (row.deleted_at) {
-      return { id, deleted_at: row.deleted_at, deleted_reason: row.deleted_reason, already_deleted: true };
-    }
-    const deleted_at = new Date().toISOString();
-    db.prepare('UPDATE memories SET deleted_at=?, deleted_reason=? WHERE id=?').run(deleted_at, deletionReason, id);
-    return { id, deleted_at, deleted_reason: deletionReason };
+    return runMutation(() => {
+      const row = db.prepare('SELECT id, deleted_at, deleted_reason FROM memories WHERE id=?').get(id);
+      if (!row) throw new Error(`forget() memory not found: ${id}`);
+      if (row.deleted_at) {
+        return { id, deleted_at: row.deleted_at, deleted_reason: row.deleted_reason, already_deleted: true };
+      }
+      const deleted_at = new Date().toISOString();
+      db.prepare('UPDATE memories SET deleted_at=?, deleted_reason=? WHERE id=?').run(deleted_at, deletionReason, id);
+      return { id, deleted_at, deleted_reason: deletionReason };
+    });
   };
 
   return { remember, forget };

--- a/packages/core/src/sandbox-worker.ts
+++ b/packages/core/src/sandbox-worker.ts
@@ -5,10 +5,10 @@
 import { createContext, runInNewContext } from 'node:vm';
 import { parentPort, workerData } from 'node:worker_threads';
 
-import { DB_PATH, openDb, openReadDb, openWriterLeaseDb } from './db.ts';
+import { openAttuneDb, openReadDb } from './db.ts';
 import { createQueryApi, createAttuneApi } from './query.ts';
-import { shouldSkipBuild } from './indexer.ts';
-import { acquireWriterLease, writerLockPathFor } from './writer-lease.ts';
+import { nodeSqliteTransactionAdapter } from './tx.ts';
+import { runRetryableWriteTransaction } from './write-coordinator.ts';
 
 if (!parentPort) throw new Error('sandbox-worker must run as a worker thread');
 const port = parentPort;
@@ -25,37 +25,15 @@ async function runScript(api: Record<string, unknown>, script: string, timeoutMs
 }
 
 async function runAttune(script: string, timeoutMs: number): Promise<unknown> {
-  const lease = acquireWriterLease({
-    lockPath: writerLockPathFor(DB_PATH),
-    openDb: openWriterLeaseDb,
-    waitMs: 1000,
-  });
-  if (!lease) throw new Error('Trajex index writer is busy; attune was not applied');
-
-  let db: ReturnType<typeof openDb> | null = null;
+  const db = openAttuneDb();
   try {
-    const ownershipDb = openReadDb();
-    try {
-      if (shouldSkipBuild(ownershipDb, { ignoreRecentBuild: true }).reason === 'daemon_active') {
-        throw new Error('Trajex daemon owns index writes; attune is read-only until the daemon stops');
-      }
-    } finally {
-      ownershipDb.close();
-    }
-
-    db = openDb();
-    db.exec('BEGIN IMMEDIATE');
-    try {
-      const result = await runScript(createAttuneApi(db), script, timeoutMs);
-      db.exec('COMMIT');
-      return result;
-    } catch (error) {
-      try { db.exec('ROLLBACK'); } catch { /* worker termination also closes the connection */ }
-      throw error;
-    }
+    const runMutation = <T>(work: () => T): T => runRetryableWriteTransaction(
+      nodeSqliteTransactionAdapter(db), work, { label: 'attune' },
+      { retryOnBeginBusy: true, budgetMs: 5000, retryDelayMs: 100, maxAttempts: 10 },
+    );
+    return await runScript(createAttuneApi(db, runMutation), script, timeoutMs);
   } finally {
-    db?.close();
-    lease.release();
+    db.close();
   }
 }
 

--- a/packages/core/src/write-coordinator.ts
+++ b/packages/core/src/write-coordinator.ts
@@ -23,6 +23,8 @@ interface TransactionDiagnostics {
 }
 
 export interface WriteRetryOptions {
+  /** BEGIN 尚未执行 work，只有明确选择的短事务可重试此类忙锁。 */
+  retryOnBeginBusy?: boolean;
   maxAttempts?: number;
   budgetMs?: number;
   retryDelayMs?: number;
@@ -82,6 +84,7 @@ export function isRetryableWriteFailure(error: unknown): boolean {
  * 与未知存活事务交给调用方处理，避免重试造成重复或覆盖。
  */
 export function runWithWriteRetry<T>(operation: () => T, {
+  retryOnBeginBusy = false,
   maxAttempts = 3,
   budgetMs = 1000,
   retryDelayMs = 25,
@@ -95,7 +98,7 @@ export function runWithWriteRetry<T>(operation: () => T, {
     } catch (error) {
       const info = diagnostics(error);
       if (info) info.attempts = attempt;
-      if (!isRetryableWriteFailure(error) || attempt >= maxAttempts) throw error;
+      if (!(isRetryableWriteFailure(error) || (retryOnBeginBusy && isBeginBusyFailure(error))) || attempt >= maxAttempts) throw error;
       const remaining = budgetMs - (now() - startedAt);
       if (remaining <= 0) throw error;
       sleep(Math.min(retryDelayMs * attempt, remaining));

--- a/tests/daemon-arbitration.test.mjs
+++ b/tests/daemon-arbitration.test.mjs
@@ -6,7 +6,7 @@ import { makeTempDir } from './temp-dirs.mjs';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { acquireWriterLease, writerLockPathFor } from '../packages/core/src/writer-lease.ts';
@@ -40,7 +40,7 @@ test('a passive query reports when a fresh daemon blocks its schema upgrade', ()
   assert.deepEqual(tables, ['index_state']);
 });
 
-test('attune reports when a fresh daemon blocks its schema upgrade', () => {
+test('attune reports an unavailable memory layer without asking a fresh daemon to upgrade it', () => {
   const home = makeTempDir('trajex-daemon-attune-');
   const trajexDir = join(home, '.trajex');
   const dbPath = join(trajexDir, 'trajex.sqlite');
@@ -56,12 +56,36 @@ test('attune reports when a fresh daemon blocks its schema upgrade', () => {
   writeFileSync(attunePath, 'return true;');
   const result = runCli(['--attune', attunePath], { home });
   assert.equal(result.status, 1);
-  assert.match(JSON.parse(result.stdout).error, /schema upgrade is blocked by daemon_active/i);
+  assert.match(JSON.parse(result.stdout).error, /predates the approved durable memory layer/i);
 
   const check = new DatabaseSync(dbPath, { readOnly: true });
   const tables = check.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(row => row.name);
   check.close();
   assert.deepEqual(tables, ['index_state']);
+});
+
+test('attune writes approved durable memory while a fresh daemon owns indexing', () => {
+  const home = makeTempDir('trajex-daemon-attune-memory-');
+  const trajexDir = join(home, '.trajex');
+  const dbPath = join(trajexDir, 'trajex.sqlite');
+  mkdirSync(trajexDir, { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(readFileSync(new URL('../packages/core/src/schema.sql', import.meta.url), 'utf8'));
+  db.prepare('INSERT INTO index_state (jsonl_path, mtime, lines_processed) VALUES (?, ?, 0)')
+    .run('__app_heartbeat__', Date.now());
+  db.close();
+
+  const memoryPath = join(home, 'decision.md');
+  const attunePath = join(home, 'attune.mjs');
+  writeFileSync(memoryPath, '# Decision\n');
+  writeFileSync(attunePath, `return remember({ path: ${JSON.stringify(memoryPath)}, summary: 'Decision: daemon-owned indexing must not block approved durable memory.' });`);
+
+  const result = runCli(['--attune', attunePath], { home });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const memory = JSON.parse(result.stdout);
+  const check = new DatabaseSync(dbPath, { readOnly: true });
+  assert.equal(check.prepare('SELECT summary FROM memories WHERE id=?').get(memory.id).summary, 'Decision: daemon-owned indexing must not block approved durable memory.');
+  check.close();
 });
 
 test('a passive query reports when another writer blocks its schema upgrade', () => {

--- a/tests/query.test.mjs
+++ b/tests/query.test.mjs
@@ -221,6 +221,35 @@ test('attune api exposes only memory mutation helpers', () => {
   db.close();
 });
 
+test('remember regenerates a colliding id instead of replacing an existing memory', () => {
+  const memoryPath = join(makeTempDir('trajex-memory-collision-'), 'memory.md');
+  writeFileSync(memoryPath, '# Memory\n');
+  const attempts = [];
+  let first = true;
+  const db = {
+    prepare(sql) {
+      assert.match(sql, /^INSERT INTO memories/);
+      return { run: (...args) => {
+        attempts.push(args[0]);
+        if (first) {
+          first = false;
+          throw Object.assign(new Error('PRIMARY KEY'), { errcode: 1555 });
+        }
+      } };
+    },
+  };
+
+  const result = createAttuneApi(db).remember({
+    path: memoryPath,
+    project: 'collision-test',
+    summary: 'Decision: a colliding memory identifier never replaces approved durable memory.',
+  });
+
+  assert.equal(attempts.length, 2);
+  assert.notEqual(attempts[0], attempts[1]);
+  assert.equal(result.id, attempts[1]);
+});
+
 test('remember stores absolute project-relative memory path', () => {
   const projectDir = makeTempDir('trajex-memory-project-');
   const memoryDir = join(projectDir, '.trajex', 'memories');

--- a/tests/runtime-cli-envelope.test.mjs
+++ b/tests/runtime-cli-envelope.test.mjs
@@ -81,6 +81,9 @@ test('--query surfaces a throw as { error, stack } and exits 1', () => {
 
 test('--attune surfaces a throw as { error, stack } and exits 1', () => {
   const home = tempHome();
+  const initPath = join(home, 'init.mjs');
+  writeFileSync(initPath, "return 'init';");
+  assert.equal(runRuntime(['--query', initPath], { home }).status, 0);
   const scriptPath = join(home, 'attune-boom.mjs');
   writeFileSync(scriptPath, "throw new Error('attune-envelope');");
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -39,7 +39,10 @@ test('runtime attune scripts expose only memory mutation helpers', () => {
   const home = tempHome();
   const memoryPath = join(home, 'memory.md');
   const scriptPath = join(home, 'attune.mjs');
+  const initPath = join(home, 'init.mjs');
   writeFileSync(memoryPath, '# Memory\n');
+  writeFileSync(initPath, "return 'init';");
+  assert.equal(runRuntime(['--query', initPath], { home }).status, 0);
   writeFileSync(scriptPath, `
     return {
       rememberType: typeof remember,

--- a/tests/write-transaction.test.mjs
+++ b/tests/write-transaction.test.mjs
@@ -9,7 +9,7 @@ import { createRequire } from 'node:module';
 import { join } from 'node:path';
 
 import { nodeSqliteTransactionAdapter, runWriteTransaction } from '../packages/core/src/tx.ts';
-import { hasUnusableTransaction, isBeginBusyFailure, isRetryableWriteFailure } from '../packages/core/src/write-coordinator.ts';
+import { hasUnusableTransaction, isBeginBusyFailure, isRetryableWriteFailure, runRetryableWriteTransaction } from '../packages/core/src/write-coordinator.ts';
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite');
@@ -166,4 +166,29 @@ test('a BEGIN failure with an active transaction is not deferrable', () => {
   assert.equal(primary.trajex.transactionActive, true);
   assert.equal(hasUnusableTransaction(primary), true);
   assert.equal(isBeginBusyFailure(primary), false);
+});
+
+test('BEGIN busy retries only when a short transaction opts in', () => {
+  const dbPath = join(makeTempDir('trajex-begin-retry-'), 'index.sqlite');
+  const holder = new DatabaseSync(dbPath);
+  holder.exec('PRAGMA busy_timeout=0; CREATE TABLE t (value TEXT); BEGIN IMMEDIATE');
+  const contender = new DatabaseSync(dbPath);
+  contender.exec('PRAGMA busy_timeout=0');
+  const tx = nodeSqliteTransactionAdapter(contender);
+
+  try {
+    assert.throws(() => runRetryableWriteTransaction(tx, () => {}), isBeginBusyFailure);
+    const result = runRetryableWriteTransaction(
+      tx,
+      () => { contender.exec("INSERT INTO t VALUES ('memory')"); return 'done'; },
+      {},
+      { retryOnBeginBusy: true, sleep: () => holder.exec('ROLLBACK') },
+    );
+    assert.equal(result, 'done');
+    assert.equal(contender.prepare('SELECT COUNT(*) AS c FROM t').get().c, 1);
+  } finally {
+    try { holder.exec('ROLLBACK'); } catch { /* released by retry */ }
+    holder.close();
+    contender.close();
+  }
 });


### PR DESCRIPTION
## Summary
- selectively ports Obelisk 8c4294e attune concurrency semantics
- lets attune mutate approved durable memory while daemon indexing is active
- prevents memory-id replacement and retries short BEGIN contention

## Verification
- npm test
- npm run typecheck
- npm run lint

🤖 Shipped via git-ship